### PR TITLE
refactor: Replace 'final int zone' with 'ZoneOffset' throughout API

### DIFF
--- a/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
@@ -48,7 +48,7 @@ public class AdminController {
         }
     )
     @GetMapping
-    public ResponseEntity<List<InfoUsersDto>> userList(@RequestParam ZoneOffset zone) {
+    public ResponseEntity<List<InfoUsersDto>> userList(@RequestParam final ZoneOffset zone) {
         return ResponseEntity.ok(adminService.findAllUsers(zone));
     }
 

--- a/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 import jakarta.validation.Valid;
 import java.util.LinkedList;
 import java.util.List;
+import java.time.ZoneOffset;
 
 @Tag(
         name = "Управление пользователями для администратора",
@@ -48,7 +49,7 @@ public class AdminController {
         }
     )
     @GetMapping
-    public ResponseEntity<List<InfoUsersDto>> userList(@RequestParam @Parameter(description = "Часовой пояс") final int zone) {
+    public ResponseEntity<List<InfoUsersDto>> userList(@RequestParam ZoneOffset zone) {
         return ResponseEntity.ok(adminService.findAllUsers(zone));
     }
 

--- a/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/admin/controllers/AdminController.java
@@ -6,7 +6,6 @@ import io.github.enkarin.bookcrossing.admin.service.AdminService;
 import io.github.enkarin.bookcrossing.constant.Constant;
 import io.github.enkarin.bookcrossing.exception.BindingErrorsException;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/io/github/enkarin/bookcrossing/admin/dto/InfoUsersDto.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/admin/dto/InfoUsersDto.java
@@ -27,21 +27,21 @@ public class InfoUsersDto {
     @Schema(description = "Время последнего входа", example = "2022-11-03T23:15:09.61")
     private final String loginDate;
 
-    public static InfoUsersDto fromUser(final User user, final int zone) {
+    public static InfoUsersDto fromUser(final User user, final ZoneOffset zone) {
         return new InfoUsersDto(UserParentDto.create(user.getUserId(), user.getName(), user.getLogin(), user.getEmail(),
                 user.getCity(), user.isAccountNonLocked(), user.isEnabled()),
                 loginDateToString(user.getLoginDate(), zone));
     }
 
-    public static InfoUsersDto fromUserDto(final UserDto user, final int zone) {
+    public static InfoUsersDto fromUserDto(final UserDto user, final ZoneOffset zone) {
         return new InfoUsersDto(UserParentDto.create(user.getUserId(), user.getName(), user.getLogin(), user.getEmail(),
                 user.getCity(), user.isAccountNonLocked(), user.isEnabled()),
                 loginDateToString(user.getLoginDate(), zone));
     }
 
-    private static String loginDateToString(final long loginDate, final int zone) {
+    private static String loginDateToString(final long loginDate, final ZoneOffset zone) {
         return loginDate == 0 ? "0" :
-                LocalDateTime.ofEpochSecond(loginDate, 0, ZoneOffset.ofHours(zone))
+                LocalDateTime.ofEpochSecond(loginDate, 0, zone)
                         .toString();
     }
 }

--- a/src/main/java/io/github/enkarin/bookcrossing/admin/service/AdminService.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/admin/service/AdminService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.time.ZoneOffset;
 
 @RequiredArgsConstructor
 @Service
@@ -42,7 +43,7 @@ public class AdminService {
         return user.isAccountNonLocked();
     }
 
-    public List<InfoUsersDto> findAllUsers(final int zone) {
+    public List<InfoUsersDto> findAllUsers(final ZoneOffset zone) {
         final Role role = roleRepository.getRoleByName("ROLE_USER");
         return userRepository.findByUserRolesOrderByUserId(role).stream()
                 .map(u -> InfoUsersDto.fromUser(u, zone))

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/controllers/CorrespondenceController.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/controllers/CorrespondenceController.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.security.Principal;
+import java.time.ZoneOffset;
 import java.util.Map;
 
 @Tag(
@@ -106,7 +107,7 @@ public class CorrespondenceController {
     @GetMapping
     public ResponseEntity<Object[]> getCorrespondence(@RequestHeader(FIRST_USER_ID) final int firstUserId,
                                                       @RequestHeader(SECOND_USER_ID) final int secondUserId,
-                                                      @RequestParam final int zone,
+                                                      @RequestParam final ZoneOffset zone,
                                                       final Principal principal) {
         return ResponseEntity.ok(correspondenceService.getChat(firstUserId, secondUserId, zone, principal.getName()).toArray());
     }

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/dto/MessageDto.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/dto/MessageDto.java
@@ -30,7 +30,7 @@ public class MessageDto {
 
     private final boolean declaim;
 
-    public static MessageDto fromMessageAndZone(final Message message, final int zone) {
+    public static MessageDto fromMessageAndZone(final Message message, final ZoneOffset zone) {
         return new MessageDto(message.getMessageId(), message.getSender().getUserId(), message.getText(),
                 LocalDateTime.ofEpochSecond(message.getDepartureDate(),
                         0, ZoneOffset.ofHours(zone)).toString(), message.isDeclaim());

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/dto/MessageDto.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/dto/MessageDto.java
@@ -33,7 +33,7 @@ public class MessageDto {
     public static MessageDto fromMessageAndZone(final Message message, final ZoneOffset zone) {
         return new MessageDto(message.getMessageId(), message.getSender().getUserId(), message.getText(),
                 LocalDateTime.ofEpochSecond(message.getDepartureDate(),
-                        0, ZoneOffset.ofHours(zone)).toString(), message.isDeclaim());
+                        0, zone).toString(), message.isDeclaim());
     }
 
     public static MessageDto fromMessage(final Message message) {

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/dto/ZonedUserCorrKeyDto.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/dto/ZonedUserCorrKeyDto.java
@@ -7,6 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import javax.annotation.concurrent.Immutable;
+import java.time.ZoneOffset;
 
 @Immutable
 @Getter
@@ -21,10 +22,10 @@ public class ZonedUserCorrKeyDto {
     private final int secondUserId;
 
     @Schema(description = "Часовой пояс")
-    private final int zone;
+    private final ZoneOffset zone;
 
     @JsonCreator
-    public static ZonedUserCorrKeyDto create(final int firstUserId, final int secondUserId, final int zone) {
+    public static ZonedUserCorrKeyDto create(final int firstUserId, final int secondUserId, final ZoneOffset zone) {
         return new ZonedUserCorrKeyDto(firstUserId, secondUserId, zone);
     }
 }

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/service/CorrespondenceService.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/service/CorrespondenceService.java
@@ -17,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneOffset;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -60,7 +61,7 @@ public class CorrespondenceService {
         correspondenceRepository.delete(correspondence);
     }
 
-    public List<MessageDto> getChat(final int firstUserId, final int secondUserId, final int zone, final String login) {
+    public List<MessageDto> getChat(final int firstUserId, final int secondUserId, final ZoneOffset zone, final String login) {
         final User user = userRepository.findByLogin(login).orElseThrow();
         final User fUser = userRepository.findById(firstUserId)
                 .orElseThrow(UserNotFoundException::new);

--- a/src/main/java/io/github/enkarin/bookcrossing/chat/service/CorrespondenceServiceHelper.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/chat/service/CorrespondenceServiceHelper.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.ZoneOffset;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
@@ -22,7 +23,7 @@ public class CorrespondenceServiceHelper {
 
     @Transactional
     public List<MessageDto> getMessages(final Predicate<Message> rules, final Correspondence correspondence,
-                                        final int zone, final User user) {
+                                        final ZoneOffset zone, final User user) {
         final var messages = correspondence.getMessage();
         final var response = messages.stream()
                 .filter(rules)

--- a/src/main/java/io/github/enkarin/bookcrossing/configuration/ZoneOffsetConverter.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/configuration/ZoneOffsetConverter.java
@@ -1,0 +1,26 @@
+package io.github.enkarin.bookcrossing.configuration;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+import java.time.ZoneOffset;
+
+@Component
+public class ZoneOffsetConverter implements Converter<String, ZoneOffset> {
+
+    @Override
+    public ZoneOffset convert(String source) {
+        if (source == null || source.isEmpty()) {
+            return ZoneOffset.UTC;
+        }
+
+        // Try parsing as hours first (e.g., "0", "2", "-5")
+        try {
+            int hours = Integer.parseInt(source);
+            return ZoneOffset.ofHours(hours);
+        } catch (NumberFormatException e) {
+            // Fall back to parsing as ISO format (e.g., "+02:00", "Z")
+            return ZoneOffset.of(source);
+        }
+    }
+}

--- a/src/main/java/io/github/enkarin/bookcrossing/configuration/ZoneOffsetConverter.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/configuration/ZoneOffsetConverter.java
@@ -9,17 +9,15 @@ import java.time.ZoneOffset;
 public class ZoneOffsetConverter implements Converter<String, ZoneOffset> {
 
     @Override
-    public ZoneOffset convert(String source) {
+    public ZoneOffset convert(final String source) {
         if (source == null || source.isEmpty()) {
             return ZoneOffset.UTC;
         }
 
-        // Try parsing as hours first (e.g., "0", "2", "-5")
         try {
-            int hours = Integer.parseInt(source);
+            final int hours = Integer.parseInt(source);
             return ZoneOffset.ofHours(hours);
         } catch (NumberFormatException e) {
-            // Fall back to parsing as ISO format (e.g., "+02:00", "Z")
             return ZoneOffset.of(source);
         }
     }

--- a/src/main/java/io/github/enkarin/bookcrossing/registration/dto/LoginRequest.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/registration/dto/LoginRequest.java
@@ -12,6 +12,8 @@ import javax.annotation.concurrent.Immutable;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.time.ZoneOffset;
+
 @Immutable
 @Getter
 @EqualsAndHashCode
@@ -28,10 +30,10 @@ public class LoginRequest {
     private final String password;
 
     @Schema(description = "Часовой пояс пользователя", example = "7")
-    private final int zone;
+    private final ZoneOffset zone;
 
     @JsonCreator
-    public static LoginRequest create(final String login, final String password, final int zone) {
+    public static LoginRequest create(final String login, final String password, final ZoneOffset zone) {
         return new LoginRequest(login, password, zone);
     }
 }

--- a/src/main/java/io/github/enkarin/bookcrossing/user/controllers/UserProfileController.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/user/controllers/UserProfileController.java
@@ -31,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
 import java.security.Principal;
+import java.time.ZoneOffset;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ public class UserProfileController {
     )
     @GetMapping
     public ResponseEntity<?> getProfile(@RequestHeader(defaultValue = "-1") @Parameter(description = "Идентификатор пользователя") final int userId, // NOSONAR
-                                        @RequestParam @Parameter(description = "Часовой пояс пользователя") final int zone,
+                                        @RequestParam @Parameter(description = "Часовой пояс пользователя") final ZoneOffset zone,
                                         final Principal principal) {
         if (userId == -1) {
             return ResponseEntity.ok(userService.getProfile(principal.getName()));
@@ -108,7 +109,7 @@ public class UserProfileController {
                     schema = @Schema(implementation = UserPublicProfileDto[].class))})
     })
     @GetMapping("/users")
-    public ResponseEntity<Object[]> getAllProfile(@RequestParam final int zone) {
+    public ResponseEntity<Object[]> getAllProfile(@RequestParam final ZoneOffset zone) {
         return ResponseEntity.ok(userService.findAllUsers(zone).toArray());
     }
 

--- a/src/main/java/io/github/enkarin/bookcrossing/user/dto/UserPublicProfileDto.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/user/dto/UserPublicProfileDto.java
@@ -40,13 +40,13 @@ public class UserPublicProfileDto {
     @Schema(description = "Книги пользователя")
     private final Set<BookModelDto> books;
 
-    public static UserPublicProfileDto fromUser(final User user, final int zone) {
+    public static UserPublicProfileDto fromUser(final User user, final ZoneOffset zone) {
         final Set<BookModelDto> books = user.getBooks().stream()
                 .map(BookModelDto::fromBook)
                 .collect(Collectors.toUnmodifiableSet());
         return new UserPublicProfileDto(user.getUserId(), user.getName(), user.getCity(),
                 user.getLoginDate() == 0 ? "0" :
-                        LocalDateTime.ofEpochSecond(user.getLoginDate(), 0, ZoneOffset.ofHours(zone))
+                        LocalDateTime.ofEpochSecond(user.getLoginDate(), 0, zone)
                                 .toString(),
                 books);
     }

--- a/src/main/java/io/github/enkarin/bookcrossing/user/service/UserService.java
+++ b/src/main/java/io/github/enkarin/bookcrossing/user/service/UserService.java
@@ -30,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
+import java.time.ZoneOffset;
 
 @RequiredArgsConstructor
 @Service
@@ -74,7 +75,7 @@ public class UserService {
         return userRepository.findByLogin(login).orElseThrow(UserNotFoundException::new);
     }
 
-    public UserPublicProfileDto findById(final int userId, final int zone) {
+    public UserPublicProfileDto findById(final int userId, final ZoneOffset zone) {
         return UserPublicProfileDto.fromUser(userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new), zone);
     }
@@ -84,7 +85,7 @@ public class UserService {
         return UserProfileDto.fromUser(user);
     }
 
-    public List<UserPublicProfileDto> findAllUsers(final int zone) {
+    public List<UserPublicProfileDto> findAllUsers(final ZoneOffset zone) {
         // TODO Performance! Too many sql queries. Should retrieve all data within single select query
         final Role role = roleRepository.getRoleByName("ROLE_USER");
         return userRepository.findByUserRolesOrderByUserId(role).stream()

--- a/src/test/java/io/github/enkarin/bookcrossing/admin/dto/InfoUsersDtoTest.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/admin/dto/InfoUsersDtoTest.java
@@ -4,13 +4,15 @@ import io.github.enkarin.bookcrossing.support.BookCrossingBaseTests;
 import io.github.enkarin.bookcrossing.support.TestDataProvider;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneOffset;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class InfoUsersDtoTest extends BookCrossingBaseTests {
 
     @Test
     void fromUserDtoShouldWorkWithLoginDate() {
-        assertThat(InfoUsersDto.fromUserDto(TestDataProvider.buildUserDto(), 0))
+        assertThat(InfoUsersDto.fromUserDto(TestDataProvider.buildUserDto(), ZoneOffset.UTC))
                 .isNotNull()
                 .satisfies(i -> {
                     assertThat(i.getLoginDate())

--- a/src/test/java/io/github/enkarin/bookcrossing/admin/service/AdminServiceTest.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/admin/service/AdminServiceTest.java
@@ -9,6 +9,7 @@ import io.github.enkarin.bookcrossing.user.dto.UserDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,15 +53,15 @@ class AdminServiceTest extends BookCrossingBaseTests {
         final List<UserDto> users = TestDataProvider.buildUsers().stream()
                 .map(this::createAndSaveUser)
                 .toList();
-        assertThat(adminService.findAllUsers(0))
+        assertThat(adminService.findAllUsers(ZoneOffset.UTC))
                 .hasSize(3)
                 .hasSameElementsAs(users.stream()
-                        .map(u -> InfoUsersDto.fromUserDto(u, 0))
+                        .map(u -> InfoUsersDto.fromUserDto(u, ZoneOffset.UTC))
                         .toList());
     }
 
     @Test
     void findAllUsersEmpty() {
-        assertThat(adminService.findAllUsers(0)).isEmpty();
+        assertThat(adminService.findAllUsers(ZoneOffset.UTC)).isEmpty();
     }
 }

--- a/src/test/java/io/github/enkarin/bookcrossing/chat/controllers/MessageControllerTest.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/chat/controllers/MessageControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpMethod;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
+import java.time.ZoneOffset;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MessageControllerTest extends BookCrossingBaseTests {
@@ -157,9 +159,9 @@ class MessageControllerTest extends BookCrossingBaseTests {
 
         execute(messageId, 200);
 
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userBot.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userBot.getLogin()))
                 .isEmpty();
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userAlex.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userAlex.getLogin()))
                 .isEmpty();
     }
 
@@ -200,9 +202,9 @@ class MessageControllerTest extends BookCrossingBaseTests {
 
         executeDeleteForMe(messageId, generateAccessToken(TestDataProvider.buildAuthBot()), 200);
 
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userBot.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userBot.getLogin()))
                 .isEmpty();
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userAlex.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userAlex.getLogin()))
                 .hasSize(1);
     }
 
@@ -218,9 +220,9 @@ class MessageControllerTest extends BookCrossingBaseTests {
 
         executeDeleteForMe(messageId, generateAccessToken(TestDataProvider.buildAuthAlex()), 200);
 
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userBot.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userBot.getLogin()))
                 .hasSize(1);
-        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), 0, userAlex.getLogin()))
+        assertThat(correspondenceService.getChat(key.getFirstUserId(), key.getSecondUserId(), ZoneOffset.UTC, userAlex.getLogin()))
                 .isEmpty();
     }
 

--- a/src/test/java/io/github/enkarin/bookcrossing/support/TestDataProvider.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/support/TestDataProvider.java
@@ -17,6 +17,8 @@ import io.github.enkarin.bookcrossing.user.dto.UserPutProfileDto;
 import lombok.experimental.UtilityClass;
 
 import jakarta.annotation.Nonnull;
+
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 
@@ -65,7 +67,7 @@ public class TestDataProvider {
     public static LoginRequest.LoginRequestBuilder<?, ?> prepareLogin() {
         return LoginRequest.builder()
                 .password("123456")
-                .zone(0);
+                .zone(ZoneOffset.UTC);
     }
 
     @Nonnull

--- a/src/test/java/io/github/enkarin/bookcrossing/user/dto/UserPublicProfileDtoTest.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/user/dto/UserPublicProfileDtoTest.java
@@ -4,6 +4,7 @@ import io.github.enkarin.bookcrossing.books.model.Book;
 import io.github.enkarin.bookcrossing.user.model.User;
 import org.junit.jupiter.api.Test;
 
+import java.time.ZoneOffset;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,7 +19,7 @@ class UserPublicProfileDtoTest {
         user.setName("name");
         user.setBooks(Stream.of(new Book()).collect(Collectors.toSet()));
 
-        final UserPublicProfileDto userProfileDto = UserPublicProfileDto.fromUser(user, 3);
+        final UserPublicProfileDto userProfileDto = UserPublicProfileDto.fromUser(user, ZoneOffset.ofHours(3));
         assertThat(userProfileDto)
                 .isNotNull()
                 .satisfies(u -> {
@@ -42,7 +43,7 @@ class UserPublicProfileDtoTest {
         user.setLoginDate(123_567);
         user.setBooks(Stream.of(new Book()).collect(Collectors.toSet()));
 
-        final UserPublicProfileDto userProfileDto = UserPublicProfileDto.fromUser(user, 3);
+        final UserPublicProfileDto userProfileDto = UserPublicProfileDto.fromUser(user, ZoneOffset.ofHours(3));
         assertThat(userProfileDto)
                 .isNotNull()
                 .satisfies(u -> {

--- a/src/test/java/io/github/enkarin/bookcrossing/user/service/UserServiceTest.java
+++ b/src/test/java/io/github/enkarin/bookcrossing/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import io.github.enkarin.bookcrossing.user.dto.UserProfileDto;
 import io.github.enkarin.bookcrossing.user.dto.UserPublicProfileDto;
 import io.github.enkarin.bookcrossing.user.dto.UserPutProfileDto;
 
+import java.time.ZoneOffset;
 import java.util.Comparator;
 
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 
 class UserServiceTest extends BookCrossingBaseTests {
-    private static final int GM_TIME_ZERO = 0;
+    private static final ZoneOffset GM_TIME_ZERO = ZoneOffset.UTC;
 
     @Test
     void saveUserCorrectUserTest() {


### PR DESCRIPTION
## Changes
- Replaced all `final int zone` parameters with `ZoneOffset zone` across the API
- Removed redundant `ZoneOffset.ofHours(zone)` calls since zone is now already a ZoneOffset
- Updated method signatures in controllers, services, and DTOs

## Files Modified
- AdminController.java
- AdminService.java
- InfoUsersDto.java
- UserPublicProfileDto.java
- UserService.java
- UserProfileController.java
- LoginRequest.java
- CorrespondenceController.java
- ZonedUserCorrKeyDto.java
- MessageDto.java
- CorrespondenceService.java
- CorrespondenceServiceHelper.java

## Benefits
- Better type safety with ZoneOffset
- Cleaner API (no magic int values)
- Fewer conversions in the code
- Aligns with Java 8+ best practices